### PR TITLE
docs: fix simple typo, undestood -> understood

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cutest
 
-Cutest is an acronym that can be undestood as ``C`` ``u``nit ``test``.
+Cutest is an acronym that can be understood as ``C`` ``u``nit ``test``.
 
 This library brings a bunch of macros in order to guide the implementation of unit tests for ``C`` projects.
 


### PR DESCRIPTION
There is a small typo in README.md.

Should read `understood` rather than `undestood`.

